### PR TITLE
Remove the redundant sudo

### DIFF
--- a/0-preparation.sh
+++ b/0-preparation.sh
@@ -11,7 +11,7 @@ WWWOwner="drupalpro"
 
 # Add current user to sudoers file - careful, this line could brick the box.
 clear
-sudo echo "$WWWOwner ALL=(ALL) NOPASSWD: ALL" | sudo tee -a "/etc/sudoers.d/$WWWOwner" > /dev/null
+echo "$WWWOwner ALL=(ALL) NOPASSWD: ALL" | sudo tee -a "/etc/sudoers.d/$WWWOwner" > /dev/null
 
 sudo chmod 0440 "/etc/sudoers.d/$WWWOwner"
 


### PR DESCRIPTION
Because of the first "sudo" on line 14, the user is forced to enter his password twice.