### PR TITLE
Install Drush 7 globally, Drush 8 locally.

### DIFF
--- a/5-install-drush.sh
+++ b/5-install-drush.sh
@@ -19,16 +19,16 @@ sudo mv composer.phar /usr/local/bin/composer
 
 composer --version
 
-# Add drush.
-composer global require drush/drush:dev-master
+# Install a default version of Drush globally.
+composer global require drush/drush:7.*
 
-# Add Drush to your system path.
+# Add Composer Global Bin to PATH.
 FILE=$HOME/.bashrc
 if [ -f $FILE ];
 then
-   sed -i '1i export PATH="$HOME/.composer/vendor/bin:$PATH"' $HOME/.bashrc
+   sed -i "1i export PATH=\"$(composer config -g home 2>/dev/null)/vendor/bin:\$PATH\"" $HOME/.bashrc
 else
-   echo 'export PATH="$HOME/.composer/vendor/bin:$PATH"' >> $HOME/.bashrc
+   echo "export PATH=\"$(composer config -g home 2>/dev/null)/vendor/bin:\$PATH\"" >> $HOME/.bashrc
 fi
 source $HOME/.bashrc
 
@@ -39,6 +39,17 @@ sudo mkdir -p /usr/share/drush/commands/
 sudo mv drush_addons/make_templates ~/make_templates
 sudo mv drush_addons /usr/share/drush/commands/quickstart
 drush cc drush
+
+# Install Drush 8.
+mkdir ~/drush8
+cd ~/drush8
+composer require drush/drush:8.*
+
+ln -sf ~/drush8/vendor/bin/drush $(composer config -g home 2>/dev/null)/vendor/bin/drush8
+
+drush8 --version
+
+drush8 cc drush
 
 #reboot
 sudo apt-get $OPT_APTGET autoremove


### PR DESCRIPTION
Install a default version of Drush (Drush 7) globally and Drush 8 in ~/drush8. The global bin path is returned by composer's config command. I think this solves #7 